### PR TITLE
Fix #3 - Actualize dependencies, bump sdk dependency do 2.0

### DIFF
--- a/lib/gps_trace.dart
+++ b/lib/gps_trace.dart
@@ -5,7 +5,7 @@ library gps_trace;
 
 import 'dart:async';
 import 'dart:math' as Math ;
-import 'package:petitparser/xml.dart';
+import 'package:xml/xml.dart';
 
 part "src/analysers.dart" ;
 part "src/beans.dart" ;

--- a/lib/src/computers.dart
+++ b/lib/src/computers.dart
@@ -403,10 +403,10 @@ class DistanceComputer{
   double distance(TracePoint start, TracePoint end){
     
     double R = 6371.0; 
-    double dLat = ( end.latitude   - start.latitude  ) * Math.PI / 180; 
-    double dLon = ( end.longitude  - start.longitude ) * Math.PI / 180;
-    double lat1 = (                  start.latitude  ) * Math.PI / 180; 
-    double lat2 = (                    end.latitude  ) * Math.PI / 180; 
+    double dLat = ( end.latitude   - start.latitude  ) * Math.pi / 180; 
+    double dLon = ( end.longitude  - start.longitude ) * Math.pi / 180;
+    double lat1 = (                  start.latitude  ) * Math.pi / 180; 
+    double lat2 = (                    end.latitude  ) * Math.pi / 180; 
     
     double a = Math.sin(dLat/2) * Math.sin(dLat/2) +
         Math.sin(dLon/2) * Math.sin(dLon/2) * Math.cos(lat1) * Math.cos(lat2); 
@@ -419,7 +419,7 @@ class DistanceComputer{
 
 class InclinationComputer{
   int inclination(num elevetionDiff, num distance){
-    return  distance ==0 ? 0 :  (   Math.atan(elevetionDiff/distance)  / Math.PI * 180  ).round() ;
+    return  distance ==0 ? 0 :  (   Math.atan(elevetionDiff/distance)  / Math.pi * 180  ).round() ;
   }
 }
 

--- a/lib/src/parsers.dart
+++ b/lib/src/parsers.dart
@@ -7,9 +7,8 @@ class GpxFileParser{
       TraceRawData traceRawData = new TraceRawData();
       List<TracePoint> points = traceRawData.points;
       
-      var parser = new XmlParser();
-      XmlDocument xmlDocument = parser.parse(gpxFileContent).value;
-      Iterator allNodesIter= xmlDocument.where((xmlNode) =>(xmlNode is XmlElement )).iterator ;
+      XmlDocument xmlDocument = parse(gpxFileContent);
+      Iterator allNodesIter= xmlDocument.descendants.where((xmlNode) =>(xmlNode is XmlElement )).iterator ;
       num index = 0;
       TracePoint previousPoint = null;
       for (; allNodesIter.moveNext();) {
@@ -29,7 +28,7 @@ class GpxFileParser{
           currentPoint.latitude  =  double.parse( trkptElement.getAttribute("lat") );
           currentPoint.longitude =  double.parse( trkptElement.getAttribute("lon") );        
           
-          Iterator eleIterator =  trkptElement.where((xmlNode) =>(xmlNode is XmlElement ) ).iterator ;
+          Iterator eleIterator =  trkptElement.descendants.where((xmlNode) =>(xmlNode is XmlElement ) ).iterator ;
           for  ( ;eleIterator.moveNext() ;){
             XmlElement eleElement = eleIterator.current;
             if (eleElement.name.toString() != "ele"){

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ author: Gerald Reinhart <gerald.reinhart@gmail.com>
 description: Parsing and analysing gps trace files
 homepage: https://github.com/GeReinhart/dart-gps-trace
 environment:
-  sdk: '>=1.0.0 <2.0.0'
+  sdk: '>=2.0.0-dev <3.0.0'
 dependencies:
-  petitparser: ">=1.0.0 <2.0.0"
+  xml: '>=3.0.0 <4.0.0'
 dev_dependencies:
-  unittest: ">=0.11.0+1 <0.12.0"
+  test: ">=1.3.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ author: Gerald Reinhart <gerald.reinhart@gmail.com>
 description: Parsing and analysing gps trace files
 homepage: https://github.com/GeReinhart/dart-gps-trace
 environment:
-  sdk: '>=2.0.0-dev <3.0.0'
+  sdk: '>=2.0.0 <3.0.0'
 dependencies:
   xml: '>=3.0.0 <4.0.0'
 dev_dependencies:

--- a/test/trace_tests.dart
+++ b/test/trace_tests.dart
@@ -1,7 +1,7 @@
 
 import 'dart:io';
 import 'dart:async';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 import '../lib/gps_trace.dart';
 
@@ -95,7 +95,7 @@ main() {
   
  test('Analyse a gpx 1.1 file', () {
     File file = new File("test/resources/openrunner.com.1255360.gpx"); // Chamchaude
-    buildTraceAnalysisFromGpxFile(file).then((trace){
+    buildTraceAnalysisFromGpxFile(file).then((trace) {
       expect(trace.upperPoint.elevetion, equals(2041));
       expect(trace.lowerPoint.elevetion, equals(1321));
       expect(trace.points.length, equals(105));
@@ -106,14 +106,13 @@ main() {
       expect(trace.points[104].latitude, equals(45.28948));    
       expect(trace.points[104].longitude, equals(5.76706));    
       expect(trace.points[104].elevetion, equals(1321));     
-      expect(trace.points[104].distance, equals(3467.202540589613));
+      expect(trace.points[104].distance, closeTo(3467.202540589613, 1e-12));
       expect(trace.startPoint.latitude, equals(45.28948));    
       expect(trace.startPoint.longitude, equals(5.76706));    
       expect(trace.startPoint.elevetion, equals(1321));
       expect(trace.up, equals(925));
-      expect(trace.inclinationUp, equals(24));  
+      expect(trace.inclinationUp, equals(24));
     });
-    
   });
  
 


### PR DESCRIPTION
This PR fixes build and changes sdk dependency for a new shiny Dart2.0.

I am a newbie in dart development, so please check out how the sdk version is set in pubspec.yaml. I think it's related to a note https://www.dartlang.org/tools/sdk Important: The Dart 2 SDK is available from the dev channel only.